### PR TITLE
Switch CLI option handling in `renumberPDB` to `Getopt::Long::Descriptive`

### DIFF
--- a/renumberPDB
+++ b/renumberPDB
@@ -5,6 +5,7 @@ use warnings;
 
 use FindBin;
 use Getopt::Long::Descriptive;
+use List::Util qw( none );
 
 use lib "$FindBin::Bin/modules";
 
@@ -15,6 +16,8 @@ use IO::DataPrinter qw(generateStandartOut);
 use IO::PDB::FormatDetector qw(detectFormat);
 use IO::PDB::Parser qw(readPDB readMMCIF);
 use IO::PDB::Exporter qw(renumberPDB);
+
+my @supportedSchemes = qw( kabat chothia );
 
 my( $opt, $usage ) = describe_options(
     'Renumber sequences in PDB files',
@@ -29,8 +32,11 @@ if( $opt->help ) {
     exit;
 }
 
-my %supportedSchemes = ( 'kabat'  => 1,
-                         'chothia'=> 1 );
+if( none { $_ eq $opt->scheme } @supportedSchemes ) {
+    local $" = ', ';
+    die "scheme '" . $opt->scheme . "' is not supported, supported schemes: " .
+        "@supportedSchemes\n";
+}
 
 my %supported_fix_mods = ( 'no_fit' => 1,
                            'fit'    => 1 );
@@ -39,13 +45,6 @@ my $numbering_scheme = $opt->scheme;
 my $pdb_file = $opt->input;
 my $file_type = $opt->filetype;
 my $error_fix_mode = 'fit';
-
-if(!$supportedSchemes{lc($numbering_scheme)})
-{
-    warn "This scheme is not supported: $numbering_scheme\n";
-    print "Supported schemes:\n";
-    die join("\n", keys %supportedSchemes), "\n";
-}
 
 $file_type = detectFormat($pdb_file) if not $file_type;
 die "Could not idetify file type $pdb_file: $!" if $file_type eq 'unknown';

--- a/renumberPDB
+++ b/renumberPDB
@@ -46,10 +46,8 @@ if( none { $_ eq $opt->errfix } @supported_fix_mods ) {
         "@supported_fix_mods\n";
 }
 
-my $numbering_scheme = $opt->scheme;
 my $pdb_file = $opt->input;
 my $file_type = $opt->filetype;
-my $error_fix_mode = $opt->errfix;
 
 $file_type = detectFormat($pdb_file) if not $file_type;
 die "Could not identify file type $pdb_file: $!" if $file_type eq 'unknown';
@@ -72,10 +70,10 @@ my $is_filter_gaps = 1;
 my @new_numbering;
 for my $model (@HMM_models) {
     for my $seq ($model->getSequences) {
-        my ($numbered_seq, $numbering_ref) = numberSeq( $seq, $error_fix_mode );
+        my ($numbered_seq, $numbering_ref) = numberSeq( $seq, $opt->errfix );
            ($numbered_seq, $numbering_ref) = convertImgt( $numbered_seq,
                                                           $seq->getDomain,
-                                                          $numbering_scheme,
+                                                          $opt->scheme,
                                                           $is_filter_gaps );
         push @new_numbering, $numbering_ref;
     }

--- a/renumberPDB
+++ b/renumberPDB
@@ -24,6 +24,7 @@ my( $opt, $usage ) = describe_options(
     'Renumber sequences in PDB files',
     [ 'scheme|s=s', 'numbering scheme', { default => 'kabat' } ],
     [ 'input|i=s', 'input file' ],
+    [ 'errFix|ef=s', 'error fixing mode', { default => 'fit' } ],
     [ 'fileType|t=s', 'input file type' ],
     [ 'help|h', 'print usage message and exit', { shortcircuit => 1 } ],
 );
@@ -37,11 +38,18 @@ if( none { $_ eq $opt->scheme } @supportedSchemes ) {
     local $" = ', ';
     die "scheme '" . $opt->scheme . "' is not supported, supported schemes: " .
         "@supportedSchemes\n";
+}
+
+if( none { $_ eq $opt->errfix } @supported_fix_mods ) {
+    local $" = ', ';
+    die "fix mode '" . $opt->errfix . "' is not supported, supported modes: " .
+        "@supported_fix_mods\n";
+}
 
 my $numbering_scheme = $opt->scheme;
 my $pdb_file = $opt->input;
 my $file_type = $opt->filetype;
-my $error_fix_mode = 'fit';
+my $error_fix_mode = $opt->errfix;
 
 $file_type = detectFormat($pdb_file) if not $file_type;
 die "Could not identify file type $pdb_file: $!" if $file_type eq 'unknown';

--- a/renumberPDB
+++ b/renumberPDB
@@ -3,8 +3,8 @@
 use strict;
 use warnings;
 
-use Getopt::Long;
 use FindBin;
+use Getopt::Long::Descriptive;
 
 use lib "$FindBin::Bin/modules";
 
@@ -16,9 +16,17 @@ use IO::PDB::FormatDetector qw(detectFormat);
 use IO::PDB::Parser qw(readPDB readMMCIF);
 use IO::PDB::Exporter qw(renumberPDB);
 
-sub usage
-{
-    die "usage\n";
+my( $opt, $usage ) = describe_options(
+    'Renumber sequences in PDB files',
+    [ 'scheme|s=s', 'numbering scheme', { default => 'kabat' } ],
+    [ 'input|i=s', 'input file' ],
+    [ 'fileType|t=s', 'input file type' ],
+    [ 'help|h', 'print usage message and exit', { shortcircuit => 1 } ],
+);
+
+if( $opt->help ) {
+    print $usage->text;
+    exit;
 }
 
 my %supportedSchemes = ( 'kabat'  => 1,
@@ -27,14 +35,11 @@ my %supportedSchemes = ( 'kabat'  => 1,
 my %supported_fix_mods = ( 'no_fit' => 1,
                            'fit'    => 1 );
 
-my( $numbering_scheme, $pdb_file, $file_type, $error_fix_mode );
+my $numbering_scheme = $opt->scheme;
+my $pdb_file = $opt->input;
+my $file_type = $opt->filetype;
+my $error_fix_mode = 'fit';
 
-GetOptions( "scheme|s=s"  => \$numbering_scheme,
-            "input|i=s"   => \$pdb_file,
-            "fileType|t=s" => \$file_type) or usage();
-
-$numbering_scheme ||= 'kabat';
-$error_fix_mode ||= 'fit';
 if(!$supportedSchemes{lc($numbering_scheme)})
 {
     warn "This scheme is not supported: $numbering_scheme\n";

--- a/renumberPDB
+++ b/renumberPDB
@@ -18,6 +18,7 @@ use IO::PDB::Parser qw(readPDB readMMCIF);
 use IO::PDB::Exporter qw(renumberPDB);
 
 my @supportedSchemes = qw( kabat chothia );
+my @supported_fix_mods = qw( no_fit fit );
 
 my( $opt, $usage ) = describe_options(
     'Renumber sequences in PDB files',
@@ -36,10 +37,6 @@ if( none { $_ eq $opt->scheme } @supportedSchemes ) {
     local $" = ', ';
     die "scheme '" . $opt->scheme . "' is not supported, supported schemes: " .
         "@supportedSchemes\n";
-}
-
-my %supported_fix_mods = ( 'no_fit' => 1,
-                           'fit'    => 1 );
 
 my $numbering_scheme = $opt->scheme;
 my $pdb_file = $opt->input;
@@ -47,7 +44,7 @@ my $file_type = $opt->filetype;
 my $error_fix_mode = 'fit';
 
 $file_type = detectFormat($pdb_file) if not $file_type;
-die "Could not idetify file type $pdb_file: $!" if $file_type eq 'unknown';
+die "Could not identify file type $pdb_file: $!" if $file_type eq 'unknown';
 
 my ($chains_ref, $sequences_ref) = $file_type eq 'cif'
                                   ? readMMCIF($pdb_file)


### PR DESCRIPTION
In this PR I have switched `renumberPDB` to use Perl package `Getopt::Long::Descriptive` for option handling. Backwards compatibility should be upheld as neither the option names nor defaults were changed.